### PR TITLE
Stop percent-encoding of numbers.

### DIFF
--- a/lib/src/percent/encoder.dart
+++ b/lib/src/percent/encoder.dart
@@ -67,6 +67,7 @@ String _convert(List<int> bytes, int start, int end) {
     // that that bit is 1 we ensure that the letter is lowercase.
     var letter = 0x20 | byte;
     if ((letter >= $a && letter <= $z) ||
+        (byte >= $0 && byte <= $9) ||
         byte == $dash ||
         byte == $dot ||
         byte == $underscore ||

--- a/test/percent_test.dart
+++ b/test/percent_test.dart
@@ -14,9 +14,9 @@ void main() {
       expect(percent.encode([
         $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p, $q, $r,
         $s, $t, $u, $v, $w, $x, $y, $z, $A, $B, $C, $D, $E, $F, $G, $H, $I, $J,
-        $K, $L, $M, $N, $O, $P, $Q, $R, $S, $T, $U, $V, $W, $X, $Y, $Z, $dash,
-        $dot, $underscore, $tilde
-      ]), equals("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-._~"));
+        $K, $L, $M, $N, $O, $P, $Q, $R, $S, $T, $U, $V, $W, $X, $Y, $Z, $0, $1,
+        $2, $3, $4, $5, $6, $7, $8, $9, $dash, $dot, $underscore, $tilde
+      ]), equals("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~"));
     });
 
     test("percent-encodes reserved ASCII characters", () {
@@ -77,8 +77,8 @@ void main() {
 
   group("decoder", () {
     test("converts percent-encoded strings to byte arrays", () {
-      expect(percent.decode("a%2Bb%3D%80"),
-          equals([$a, $plus, $b, $equal, 0x80]));
+      expect(percent.decode("a%2Bb%3D%801"),
+          equals([$a, $plus, $b, $equal, 0x80, $1]));
     });
 
     test("supports lowercase letters", () {
@@ -108,12 +108,12 @@ void main() {
       });
 
       test("converts percent to byte arrays", () {
-        sink.add("a%2Bb%3D%80");
-        expect(results, equals([[$a, $plus, $b, $equal, 0x80]]));
+        sink.add("a%2Bb%3D%801");
+        expect(results, equals([[$a, $plus, $b, $equal, 0x80, $1]]));
 
         sink.add("%00%01%FE%FF");
         expect(results,
-            equals([[$a, $plus, $b, $equal, 0x80], [0x00, 0x01, 0xfe, 0xff]]));
+            equals([[$a, $plus, $b, $equal, 0x80, $1], [0x00, 0x01, 0xfe, 0xff]]));
       });
 
       test("supports trailing percents and digits split across chunks", () {


### PR DESCRIPTION
RFC 3986 states that numbers are unreserved characters:

> Characters that are allowed in a URI but do not have a reserved purpose are called unreserved. These include uppercase and lowercase letters, decimal digits, hyphen, period, underscore, and tilde.
> 
> ```
> unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
> ```
> 
> [...]
> 
> For consistency, percent-encoded octets in the ranges of ALPHA (%41-%5A
> and %61-%7A), DIGIT (%30-%39), hyphen (%2D), period (%2E), underscore
> (%5F), or tilde (%7E) should not be created by URI producers

There were no tests or code specifically handling numbers so I believe this is just an oversight. This change adds numbers to the test of reserved characters as well as a couple of the additional tests that had alpha characters in.

This fixes dart-lang/core#254.

I've signed the CLA but I'm not sure how to submit this for review (the contributing file doesn't explain much); is that done here in the PR or should do I need to do something to add this to codereview.chromium.org system?
