### PR TITLE
Added IdentityCodec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.0
+
+ * Added an `IdentityCodec<T>` which implements `Codec<T,T>` for use as default
+   value for in functions accepting an optional `Codec` as parameter.
+
 ## 2.0.2
 
 * Set max SDK version to `<3.0.0`, and adjust other dependencies.

--- a/lib/convert.dart
+++ b/lib/convert.dart
@@ -7,5 +7,6 @@ library convert;
 export 'src/accumulator_sink.dart';
 export 'src/byte_accumulator_sink.dart';
 export 'src/hex.dart';
+export 'src/identity_codec.dart';
 export 'src/percent.dart';
 export 'src/string_accumulator_sink.dart';

--- a/lib/src/identity_codec.dart
+++ b/lib/src/identity_codec.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+
+class _IdentityConverter<T> extends Converter<T, T> {
+  const _IdentityConverter();
+  T convert(T input) => input;
+}
+
+/// A [Codec] that performs the identity conversion (changing nothing) in both
+/// directions.
+///
+/// The identity codec passes input directly to output in both directions.
+/// This class can be used as a base when combining multiple codecs,
+/// because fusing the identity codec with any other codec gives the other
+/// codec back.
+///
+/// Note, that when fused with another [Codec] the identity codec disppears.
+class IdentityCodec<T> extends Codec<T, T> {
+  const IdentityCodec();
+
+  Converter<T, T> get decoder => _IdentityConverter<T>();
+  Converter<T, T> get encoder => _IdentityConverter<T>();
+
+  /// Fuse with an other codec.
+  ///
+  /// Fusing with the identify converter is a no-op, so this always return
+  /// [other].
+  Codec<T, R> fuse<R>(Codec<T, R> other) => other;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: convert
-version: 2.0.2
+version: 2.1.0
 description: Utilities for converting between data representations.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/convert

--- a/test/identity_codec_test.dart
+++ b/test/identity_codec_test.dart
@@ -1,0 +1,23 @@
+import 'dart:convert';
+import 'package:convert/convert.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('IdentityCodec', () {
+    test('encode', () {
+      final codec = IdentityCodec<String>();
+      expect(codec.encode('hello-world'), equals('hello-world'));
+    });
+
+    test('decode', () {
+      final codec = IdentityCodec<String>();
+      expect(codec.decode('hello-world'), equals('hello-world'));
+    });
+
+    test('fuse', () {
+      final stringCodec = IdentityCodec<String>();
+      final utf8Strings = stringCodec.fuse(utf8);
+      expect(utf8Strings, equals(utf8));
+    });
+  });
+}


### PR DESCRIPTION
This is useful you're making a parameterized type that can be fused with a `Codec` to create a wrapper with different type parameters...

**Example** of when this could be useful to have:
```dart
T someFunction<S,T>(S value, [Codec<S,T> codec = const IdentityCodec()]) {
  ...
}
```
When implementing functions that accept an optional `Codec` a good default is `IdentityCodec`, if you expect users to use the function without the `Codec`.