### PR TITLE
Make _IdentityConverter compatible with Dart SDK 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+ * Fixed a DDC compilation regression for consumers using the Dart 1.x SDK that was introduced in `2.1.0`.
+
 ## 2.1.0
 
  * Added an `IdentityCodec<T>` which implements `Codec<T,T>` for use as default

--- a/lib/src/identity_codec.dart
+++ b/lib/src/identity_codec.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 class _IdentityConverter<T> extends Converter<T, T> {
-  const _IdentityConverter();
+  _IdentityConverter();
   T convert(T input) => input;
 }
 
@@ -17,8 +17,8 @@ class _IdentityConverter<T> extends Converter<T, T> {
 class IdentityCodec<T> extends Codec<T, T> {
   const IdentityCodec();
 
-  Converter<T, T> get decoder => _IdentityConverter<T>();
-  Converter<T, T> get encoder => _IdentityConverter<T>();
+  Converter<T, T> get decoder => new _IdentityConverter<T>();
+  Converter<T, T> get encoder => new _IdentityConverter<T>();
 
   /// Fuse with an other codec.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: convert
-version: 2.1.0
+version: 2.1.1
 description: Utilities for converting between data representations.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/convert


### PR DESCRIPTION
### Problem

#17 was merged and released in version `2.1.0` without changing the lower-bound of the Dart SDK to `>=2.0.0`. The changes in #17 includes the construction of an `_IdentityConverter` instance without the `new` or `const` keyword, which is a Dart SDK 2.x-only feature. 

This causes a regression for Dart 1.x SDK consumers building their application using the Dart Dev Compiler:

```
Error compiling dartdevc module:convert|lib/lib__convert.js

[error] '_IdentityConverter' isn't a function. (package:convert/src/identity_codec.dart, line 20, col 34)
[error] '_IdentityConverter' isn't a function. (package:convert/src/identity_codec.dart, line 21, col 34)
```

### Solution

Use the `new` keyword to construct the instance. I attempted to keep it a `const`, but it does not appear that `const` constructors can have generic parameters using the Dart 1.x SDK.

---

@jonasfj @kevmoo @lrhn @jayudey-wf @robbecker-wf

