### PR TITLE
Prepare for the 2.10 Dart SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,32 @@ language: dart
 dart:
   - dev
 
-dart_task:
-  - test: --enable-experiment=non-nullable --platform vm
-  - test: --enable-experiment=non-nullable --platform chrome
-  - dartanalyzer: --enable-experiment=non-nullable --fatal-warnings --fatal-infos .
-
-matrix:
+jobs:
   include:
-    - dart: dev
-      dart_task: dartfmt
+    - stage: analyze_and_format
+      name: "Analyze lib/"
+      os: linux
+      script: dartanalyzer --fatal-warnings --fatal-infos lib/
+    - stage: analyze_and_format
+      name: "Analyze test/"
+      os: linux
+      script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos test/
+    - stage: analyze_and_format
+      name: "Format"
+      os: linux
+      script: dartfmt -n --set-exit-if-changed .
+    - stage: test
+      name: "Vm Tests"
+      os: linux
+      script: pub run --enable-experiment=non-nullable test -p vm
+    - stage: test
+      name: "Web Tests"
+      os: linux
+      script: pub run --enable-experiment=non-nullable test -p chrome
+
+stages:
+  - analyze_and_format
+  - test
 
 # Only building master means that we don't run two builds for each pull request.
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@ language: dart
 
 dart:
   - dev
-  - 2.0.0
 
 dart_task:
-  - test: --platform vm
-  - test: --platform chrome
-  - dartanalyzer: --fatal-warnings --fatal-infos .
+  - test: --enable-experiment=non-nullable --platform vm
+  - test: --enable-experiment=non-nullable --platform chrome
+  - dartanalyzer: --enable-experiment=non-nullable --fatal-warnings --fatal-infos .
 
 matrix:
   include:
@@ -16,7 +15,7 @@ matrix:
 
 # Only building master means that we don't run two builds for each pull request.
 branches:
-  only: [master]
+  only: [master, null_safety]
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
     - stage: analyze_and_format
       name: "Analyze lib/"
       os: linux
-      script: dartanalyzer --fatal-warnings --fatal-infos lib/
+      script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos lib/
     - stage: analyze_and_format
       name: "Analyze test/"
       os: linux

--- a/lib/src/hex/decoder.dart
+++ b/lib/src/hex/decoder.dart
@@ -66,7 +66,7 @@ class _HexDecoderSink extends StringConversionSinkBase {
     } else {
       var hexPairs = (end - start - 1) ~/ 2;
       bytes = Uint8List(1 + hexPairs);
-      bytes[0] = _lastDigit!/*!*/ + digitForCodeUnit(codeUnits, start);
+      bytes[0] = _lastDigit! + digitForCodeUnit(codeUnits, start);
       start++;
       bytesStart = 1;
     }
@@ -126,7 +126,7 @@ class _HexDecoderByteSink extends ByteConversionSinkBase {
     } else {
       var hexPairs = (end - start - 1) ~/ 2;
       bytes = Uint8List(1 + hexPairs);
-      bytes[0] = _lastDigit!/*!*/ + digitForCodeUnit(chunk, start);
+      bytes[0] = _lastDigit! + digitForCodeUnit(chunk, start);
       start++;
       bytesStart = 1;
     }

--- a/lib/src/percent/decoder.dart
+++ b/lib/src/percent/decoder.dart
@@ -81,7 +81,7 @@ class _PercentDecoderSink extends StringConversionSinkBase {
     }
 
     if (_lastDigit != null) {
-      buffer.add(_lastDigit!/*!*/ + digitForCodeUnit(codeUnits, start));
+      buffer.add(_lastDigit! + digitForCodeUnit(codeUnits, start));
       start++;
     }
 
@@ -146,7 +146,7 @@ class _PercentDecoderByteSink extends ByteConversionSinkBase {
     }
 
     if (_lastDigit != null) {
-      buffer.add(_lastDigit!/*!*/ + digitForCodeUnit(chunk, start));
+      buffer.add(_lastDigit! + digitForCodeUnit(chunk, start));
       start++;
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Utilities for converting between data representations.
 homepage: https://github.com/dart-lang/convert
 
 environment:
-  sdk: '>=2.9.0-1 <3.0.0'
+  sdk: '>=2.10.0-0 <2.10.0'
 
 dependencies:
   charcode: ^1.1.0
@@ -16,62 +16,45 @@ dev_dependencies:
 
 dependency_overrides:
   async:
-    git:
-      url: git://github.com/dart-lang/async.git
-      ref: null_safety
+    git: git://github.com/dart-lang/async.git
   boolean_selector:
-    git:
-      url: git://github.com/dart-lang/boolean_selector.git
-      ref: null_safety
+    git: git://github.com/dart-lang/boolean_selector.git
   charcode:
-    git:
-      url: git://github.com/dart-lang/charcode.git
-      ref: null_safety
+    git: git://github.com/dart-lang/charcode.git
   collection:
+    git: git://github.com/dart-lang/collection.git
+  js:
     git:
-      url: git://github.com/dart-lang/collection.git
-      ref: null_safety
+      url: git://github.com/dart-lang/sdk.git
+      ref: 2-10-pkgs
+      path: pkg/js
   matcher:
-    git:
-      url: git://github.com/dart-lang/matcher.git
-      ref: null_safety
+    git: git://github.com/dart-lang/matcher.git
   meta:
     git:
       url: git://github.com/dart-lang/sdk.git
-      ref: null_safety-pkgs
+      ref: 2-10-pkgs
       path: pkg/meta
   path:
-    git:
-      url: git://github.com/dart-lang/path.git
-      ref: null_safety
+    git: git://github.com/dart-lang/path.git
   pedantic:
-    git:
-      url: git://github.com/dart-lang/pedantic.git
-      ref: null_safety
+    git: git://github.com/dart-lang/pedantic.git
   pool:
-    git:
-      url: git://github.com/dart-lang/pool.git
-      ref: null_safety
+    git: git://github.com/dart-lang/pool.git
+  source_maps:
+    git: git://github.com/dart-lang/source_maps.git
+  source_map_stack_trace:
+    git: git://github.com/dart-lang/source_map_stack_trace.git
   source_span:
-    git:
-      url: git://github.com/dart-lang/source_span.git
-      ref: null_safety
+    git: git://github.com/dart-lang/source_span.git
   stack_trace:
-    git:
-      url: git://github.com/dart-lang/stack_trace.git
-      ref: null_safety
+    git: git://github.com/dart-lang/stack_trace.git
   stream_channel:
-    git:
-      url: git://github.com/dart-lang/stream_channel.git
-      ref: null_safety
+    git: git://github.com/dart-lang/stream_channel.git
   string_scanner:
-    git:
-      url: git://github.com/dart-lang/string_scanner.git
-      ref: null_safety
+    git: git://github.com/dart-lang/string_scanner.git
   term_glyph:
-    git:
-      url: git://github.com/dart-lang/term_glyph.git
-      ref: null_safety
+    git: git://github.com/dart-lang/term_glyph.git
   test_api:
     git:
       url: git://github.com/dart-lang/test.git
@@ -88,6 +71,4 @@ dependency_overrides:
       ref: null_safety
       path: pkgs/test
   typed_data:
-    git:
-      url: git://github.com/dart-lang/typed_data.git
-      ref: null_safety
+    git: git://github.com/dart-lang/typed_data.git

--- a/test/byte_accumulator_sink_test.dart
+++ b/test/byte_accumulator_sink_test.dart
@@ -6,7 +6,7 @@ import 'package:convert/convert.dart';
 import 'package:test/test.dart';
 
 void main() {
-  /*late*/ late ByteAccumulatorSink sink;
+  late ByteAccumulatorSink sink;
   setUp(() {
     sink = ByteAccumulatorSink();
   });

--- a/test/hex_test.dart
+++ b/test/hex_test.dart
@@ -79,7 +79,7 @@ void main() {
     });
 
     group("with chunked conversion", () {
-      /*late*/ late List<List<int>> results;
+      late List<List<int>> results;
       var sink;
       setUp(() {
         results = [];

--- a/test/percent_test.dart
+++ b/test/percent_test.dart
@@ -186,7 +186,7 @@ void main() {
     });
 
     group("with chunked conversion", () {
-      /*late*/ late List<List<int>> results;
+      late List<List<int>> results;
       var sink;
       setUp(() {
         results = [];


### PR DESCRIPTION
Set the min SDK to 2.10.0-0 to get a language version of `2.10`.

Move dependency overrides to the master branches for the packages which
support the 2.10 SDK on the master branch.

Update travis config to run with `--enable-experiment=non-nullable` and
test on the `null_safety` branch.