### PR TITLE
Remove experiment flag from analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,9 @@ dart:
 jobs:
   include:
     - stage: analyze_and_format
-      name: "Analyze lib/"
+      name: "Analyze"
       os: linux
-      script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos lib/
-    - stage: analyze_and_format
-      name: "Analyze test/"
-      os: linux
-      script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos test/
+      script: dartanalyzer  --fatal-warnings --fatal-infos .
     - stage: analyze_and_format
       name: "Format"
       os: linux

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Utilities for converting between data representations.
 homepage: https://github.com/dart-lang/convert
 
 environment:
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-2.0.dev <2.10.0'
 
 dependencies:
   charcode: ^1.1.0


### PR DESCRIPTION
Remove the flag from the `dartanalyzer` command and combine the lib and
test analysis into a single step.

Bump min SDK to the one which includes this package in the allow list.