### PR TITLE
Move from pedantic to lints package

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.0
         with:
-          channel: ${{ matrix.sdk }}
+          sdk: ${{ matrix.sdk }}
       - id: install
         name: Install dependencies
         run: dart pub get
@@ -38,7 +38,7 @@ jobs:
 
   # Run tests on a matrix consisting of two dimensions:
   # 1. OS: ubuntu-latest, (macos-latest, windows-latest)
-  # 2. release channel: dev
+  # 2. release sdk: dev
   test:
     needs: analyze
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.2-dev
+
 ## 3.0.1
 
 * Dependency clean-up.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,12 +1,7 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 analyzer:
   strong-mode:
     implicit-casts: false
-
-  errors:
-    # Ignore still failing lints from latest pkg:pedantic
-    annotate_overrides: ignore
-    prefer_single_quotes: ignore
 
 linter:
   rules:

--- a/lib/src/accumulator_sink.dart
+++ b/lib/src/accumulator_sink.dart
@@ -23,6 +23,7 @@ class AccumulatorSink<T> implements Sink<T> {
     _events.clear();
   }
 
+  @override
   void add(T event) {
     if (_isClosed) {
       throw StateError("Can't add to a closed sink.");
@@ -31,6 +32,7 @@ class AccumulatorSink<T> implements Sink<T> {
     _events.add(event);
   }
 
+  @override
   void close() {
     _isClosed = true;
   }

--- a/lib/src/byte_accumulator_sink.dart
+++ b/lib/src/byte_accumulator_sink.dart
@@ -30,14 +30,16 @@ class ByteAccumulatorSink extends ByteConversionSinkBase {
     _buffer.clear();
   }
 
-  void add(List<int> bytes) {
+  @override
+  void add(List<int> chunk) {
     if (_isClosed) {
       throw StateError("Can't add to a closed sink.");
     }
 
-    _buffer.addAll(bytes);
+    _buffer.addAll(chunk);
   }
 
+  @override
   void addSlice(List<int> chunk, int start, int end, bool isLast) {
     if (_isClosed) {
       throw StateError("Can't add to a closed sink.");
@@ -47,6 +49,7 @@ class ByteAccumulatorSink extends ByteConversionSinkBase {
     if (isLast) _isClosed = true;
   }
 
+  @override
   void close() {
     _isClosed = true;
   }

--- a/lib/src/codepage.dart
+++ b/lib/src/codepage.dart
@@ -162,7 +162,9 @@ const _ascii = "$_noControls"
 /// A code page is a way to map bytes to character.
 /// As such, it can only represent 256 different characters.
 class CodePage extends Encoding {
+  @override
   final CodePageDecoder decoder;
+  @override
   final String name;
   CodePageEncoder? _encoder;
 
@@ -213,13 +215,16 @@ class CodePage extends Encoding {
   int operator [](int byte) => decoder._char(byte);
 
   /// Encodes [input] using `encoder.convert`.
+  @override
   Uint8List encode(String input, {int? invalidCharacter}) =>
       encoder.convert(input, invalidCharacter: invalidCharacter);
 
   /// Decodes [bytes] using `encoder.convert`.
+  @override
   String decode(List<int> bytes, {bool allowInvalid = false}) =>
       decoder.convert(bytes, allowInvalid: allowInvalid);
 
+  @override
   CodePageEncoder get encoder => _encoder ??= decoder._createEncoder();
 }
 
@@ -237,6 +242,7 @@ abstract class CodePageDecoder implements Converter<List<int>, String> {
   /// or byte values not defined as a character in the code page,
   /// are emitted as U+FFFD (the Unicode invalid character).
   /// If not true, the bytes must be calid and defined characters.
+  @override
   String convert(List<int> input, {bool allowInvalid = false});
 
   CodePageEncoder _createEncoder();
@@ -277,6 +283,7 @@ class _NonBmpCodePageDecoder extends Converter<List<int>, String>
   _NonBmpCodePageDecoder(String characters) : this._(_buildMapping(characters));
   _NonBmpCodePageDecoder._(this._characters);
 
+  @override
   int _char(int byte) => _characters[byte];
 
   static Uint32List _buildMapping(String characters) {
@@ -296,6 +303,7 @@ class _NonBmpCodePageDecoder extends Converter<List<int>, String>
     return result;
   }
 
+  @override
   CodePageEncoder _createEncoder() {
     var result = <int, int>{};
     for (var i = 0; i < 256; i++) {
@@ -307,6 +315,7 @@ class _NonBmpCodePageDecoder extends Converter<List<int>, String>
     return CodePageEncoder._(result);
   }
 
+  @override
   String convert(List<int> input, {bool allowInvalid = false}) {
     var buffer = Uint32List(input.length);
     for (var i = 0; i < input.length; i++) {
@@ -328,8 +337,10 @@ class _BmpCodePageDecoder extends Converter<List<int>, String>
     }
   }
 
+  @override
   int _char(int byte) => _characters.codeUnitAt(byte);
 
+  @override
   String convert(List<int> bytes, {bool allowInvalid = false}) {
     if (allowInvalid) return _convertAllowInvalid(bytes);
     var count = bytes.length;
@@ -364,6 +375,7 @@ class _BmpCodePageDecoder extends Converter<List<int>, String>
     return String.fromCharCodes(codeUnits);
   }
 
+  @override
   CodePageEncoder _createEncoder() => CodePageEncoder._bmp(_characters);
 }
 
@@ -396,6 +408,7 @@ class CodePageEncoder extends Converter<String, List<int>> {
   /// If [input] contains characters that are not available
   /// in this code page, they are replaced by the [invalidCharacter] byte,
   /// and then [invalidCharacter] must have been supplied.
+  @override
   Uint8List convert(String input, {int? invalidCharacter}) {
     if (invalidCharacter != null) {
       RangeError.checkValueInInterval(

--- a/lib/src/hex.dart
+++ b/lib/src/hex.dart
@@ -22,7 +22,9 @@ const hex = HexCodec._();
 ///
 /// This should be used via the [hex] field.
 class HexCodec extends Codec<List<int>, String> {
-  HexEncoder get encoder => hexEncoder;
+  @override
+    HexEncoder get encoder => hexEncoder;
+  @override
   HexDecoder get decoder => hexDecoder;
 
   const HexCodec._();

--- a/lib/src/hex.dart
+++ b/lib/src/hex.dart
@@ -23,7 +23,7 @@ const hex = HexCodec._();
 /// This should be used via the [hex] field.
 class HexCodec extends Codec<List<int>, String> {
   @override
-    HexEncoder get encoder => hexEncoder;
+  HexEncoder get encoder => hexEncoder;
   @override
   HexDecoder get decoder => hexDecoder;
 

--- a/lib/src/hex/decoder.dart
+++ b/lib/src/hex/decoder.dart
@@ -20,18 +20,20 @@ const hexDecoder = HexDecoder._();
 class HexDecoder extends Converter<String, List<int>> {
   const HexDecoder._();
 
-  List<int> convert(String string) {
-    if (!string.length.isEven) {
+  @override
+    List<int> convert(String input) {
+    if (!input.length.isEven) {
       throw FormatException(
-          "Invalid input length, must be even.", string, string.length);
+          "Invalid input length, must be even.", input, input.length);
     }
 
-    var bytes = Uint8List(string.length ~/ 2);
-    _decode(string.codeUnits, 0, string.length, bytes, 0);
+    var bytes = Uint8List(input.length ~/ 2);
+    _decode(input.codeUnits, 0, input.length, bytes, 0);
     return bytes;
   }
 
-  StringConversionSink startChunkedConversion(Sink<List<int>> sink) =>
+  @override
+    StringConversionSink startChunkedConversion(Sink<List<int>> sink) =>
       _HexDecoderSink(sink);
 }
 
@@ -49,7 +51,8 @@ class _HexDecoderSink extends StringConversionSinkBase {
 
   _HexDecoderSink(this._sink);
 
-  void addSlice(String string, int start, int end, bool isLast) {
+  @override
+    void addSlice(String string, int start, int end, bool isLast) {
     RangeError.checkValidRange(start, end, string.length);
 
     if (start == end) {
@@ -77,10 +80,12 @@ class _HexDecoderSink extends StringConversionSinkBase {
     if (isLast) _close(string, end);
   }
 
-  ByteConversionSink asUtf8Sink(bool allowMalformed) =>
+  @override
+    ByteConversionSink asUtf8Sink(bool allowMalformed) =>
       _HexDecoderByteSink(_sink);
 
-  void close() => _close();
+  @override
+    void close() => _close();
 
   /// Like [close], but includes [string] and [index] in the [FormatException]
   /// if one is thrown.
@@ -108,9 +113,11 @@ class _HexDecoderByteSink extends ByteConversionSinkBase {
 
   _HexDecoderByteSink(this._sink);
 
-  void add(List<int> chunk) => addSlice(chunk, 0, chunk.length, false);
+  @override
+    void add(List<int> chunk) => addSlice(chunk, 0, chunk.length, false);
 
-  void addSlice(List<int> chunk, int start, int end, bool isLast) {
+  @override
+    void addSlice(List<int> chunk, int start, int end, bool isLast) {
     RangeError.checkValidRange(start, end, chunk.length);
 
     if (start == end) {
@@ -137,6 +144,7 @@ class _HexDecoderByteSink extends ByteConversionSinkBase {
     if (isLast) _close(chunk, end);
   }
 
+  @override
   void close() => _close();
 
   /// Like [close], but includes [chunk] and [index] in the [FormatException]

--- a/lib/src/hex/decoder.dart
+++ b/lib/src/hex/decoder.dart
@@ -21,7 +21,7 @@ class HexDecoder extends Converter<String, List<int>> {
   const HexDecoder._();
 
   @override
-    List<int> convert(String input) {
+  List<int> convert(String input) {
     if (!input.length.isEven) {
       throw FormatException(
           "Invalid input length, must be even.", input, input.length);
@@ -33,7 +33,7 @@ class HexDecoder extends Converter<String, List<int>> {
   }
 
   @override
-    StringConversionSink startChunkedConversion(Sink<List<int>> sink) =>
+  StringConversionSink startChunkedConversion(Sink<List<int>> sink) =>
       _HexDecoderSink(sink);
 }
 
@@ -52,7 +52,7 @@ class _HexDecoderSink extends StringConversionSinkBase {
   _HexDecoderSink(this._sink);
 
   @override
-    void addSlice(String string, int start, int end, bool isLast) {
+  void addSlice(String string, int start, int end, bool isLast) {
     RangeError.checkValidRange(start, end, string.length);
 
     if (start == end) {
@@ -81,11 +81,11 @@ class _HexDecoderSink extends StringConversionSinkBase {
   }
 
   @override
-    ByteConversionSink asUtf8Sink(bool allowMalformed) =>
+  ByteConversionSink asUtf8Sink(bool allowMalformed) =>
       _HexDecoderByteSink(_sink);
 
   @override
-    void close() => _close();
+  void close() => _close();
 
   /// Like [close], but includes [string] and [index] in the [FormatException]
   /// if one is thrown.
@@ -114,10 +114,10 @@ class _HexDecoderByteSink extends ByteConversionSinkBase {
   _HexDecoderByteSink(this._sink);
 
   @override
-    void add(List<int> chunk) => addSlice(chunk, 0, chunk.length, false);
+  void add(List<int> chunk) => addSlice(chunk, 0, chunk.length, false);
 
   @override
-    void addSlice(List<int> chunk, int start, int end, bool isLast) {
+  void addSlice(List<int> chunk, int start, int end, bool isLast) {
     RangeError.checkValidRange(start, end, chunk.length);
 
     if (start == end) {

--- a/lib/src/hex/encoder.dart
+++ b/lib/src/hex/encoder.dart
@@ -35,12 +35,12 @@ class _HexEncoderSink extends ByteConversionSinkBase {
   _HexEncoderSink(this._sink);
 
   @override
-    void add(List<int> chunk) {
+  void add(List<int> chunk) {
     _sink.add(_convert(chunk, 0, chunk.length));
   }
 
   @override
-    void addSlice(List<int> chunk, int start, int end, bool isLast) {
+  void addSlice(List<int> chunk, int start, int end, bool isLast) {
     RangeError.checkValidRange(start, end, chunk.length);
     _sink.add(_convert(chunk, start, end));
     if (isLast) _sink.close();

--- a/lib/src/hex/encoder.dart
+++ b/lib/src/hex/encoder.dart
@@ -19,8 +19,10 @@ const hexEncoder = HexEncoder._();
 class HexEncoder extends Converter<List<int>, String> {
   const HexEncoder._();
 
-  String convert(List<int> bytes) => _convert(bytes, 0, bytes.length);
+  @override
+  String convert(List<int> input) => _convert(input, 0, input.length);
 
+  @override
   ByteConversionSink startChunkedConversion(Sink<String> sink) =>
       _HexEncoderSink(sink);
 }
@@ -32,16 +34,19 @@ class _HexEncoderSink extends ByteConversionSinkBase {
 
   _HexEncoderSink(this._sink);
 
-  void add(List<int> chunk) {
+  @override
+    void add(List<int> chunk) {
     _sink.add(_convert(chunk, 0, chunk.length));
   }
 
-  void addSlice(List<int> chunk, int start, int end, bool isLast) {
+  @override
+    void addSlice(List<int> chunk, int start, int end, bool isLast) {
     RangeError.checkValidRange(start, end, chunk.length);
     _sink.add(_convert(chunk, start, end));
     if (isLast) _sink.close();
   }
 
+  @override
   void close() {
     _sink.close();
   }

--- a/lib/src/identity_codec.dart
+++ b/lib/src/identity_codec.dart
@@ -2,7 +2,8 @@ import 'dart:convert';
 
 class _IdentityConverter<T> extends Converter<T, T> {
   _IdentityConverter();
-  T convert(T input) => input;
+  @override
+    T convert(T input) => input;
 }
 
 /// A [Codec] that performs the identity conversion (changing nothing) in both
@@ -17,12 +18,15 @@ class _IdentityConverter<T> extends Converter<T, T> {
 class IdentityCodec<T> extends Codec<T, T> {
   const IdentityCodec();
 
-  Converter<T, T> get decoder => _IdentityConverter<T>();
-  Converter<T, T> get encoder => _IdentityConverter<T>();
+  @override
+    Converter<T, T> get decoder => _IdentityConverter<T>();
+  @override
+    Converter<T, T> get encoder => _IdentityConverter<T>();
 
   /// Fuse with an other codec.
   ///
   /// Fusing with the identify converter is a no-op, so this always return
   /// [other].
+  @override
   Codec<T, R> fuse<R>(Codec<T, R> other) => other;
 }

--- a/lib/src/identity_codec.dart
+++ b/lib/src/identity_codec.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 class _IdentityConverter<T> extends Converter<T, T> {
   _IdentityConverter();
   @override
-    T convert(T input) => input;
+  T convert(T input) => input;
 }
 
 /// A [Codec] that performs the identity conversion (changing nothing) in both
@@ -19,9 +19,9 @@ class IdentityCodec<T> extends Codec<T, T> {
   const IdentityCodec();
 
   @override
-    Converter<T, T> get decoder => _IdentityConverter<T>();
+  Converter<T, T> get decoder => _IdentityConverter<T>();
   @override
-    Converter<T, T> get encoder => _IdentityConverter<T>();
+  Converter<T, T> get encoder => _IdentityConverter<T>();
 
   /// Fuse with an other codec.
   ///

--- a/lib/src/percent.dart
+++ b/lib/src/percent.dart
@@ -32,7 +32,7 @@ const percent = PercentCodec._();
 /// [Uri.encodeQueryComponent].
 class PercentCodec extends Codec<List<int>, String> {
   @override
-    PercentEncoder get encoder => percentEncoder;
+  PercentEncoder get encoder => percentEncoder;
   @override
   PercentDecoder get decoder => percentDecoder;
 

--- a/lib/src/percent.dart
+++ b/lib/src/percent.dart
@@ -31,7 +31,9 @@ const percent = PercentCodec._();
 /// interprets `+` as `0x2B` rather than `0x20` as emitted by
 /// [Uri.encodeQueryComponent].
 class PercentCodec extends Codec<List<int>, String> {
-  PercentEncoder get encoder => percentEncoder;
+  @override
+    PercentEncoder get encoder => percentEncoder;
+  @override
   PercentDecoder get decoder => percentDecoder;
 
   const PercentCodec._();

--- a/lib/src/percent/decoder.dart
+++ b/lib/src/percent/decoder.dart
@@ -28,19 +28,21 @@ const _lastPercent = -1;
 class PercentDecoder extends Converter<String, List<int>> {
   const PercentDecoder._();
 
-  List<int> convert(String string) {
+  @override
+    List<int> convert(String input) {
     var buffer = Uint8Buffer();
-    var lastDigit = _decode(string.codeUnits, 0, string.length, buffer);
+    var lastDigit = _decode(input.codeUnits, 0, input.length, buffer);
 
     if (lastDigit != null) {
       throw FormatException(
-          "Input ended with incomplete encoded byte.", string, string.length);
+          "Input ended with incomplete encoded byte.", input, input.length);
     }
 
     return buffer.buffer.asUint8List(0, buffer.length);
   }
 
-  StringConversionSink startChunkedConversion(Sink<List<int>> sink) =>
+  @override
+    StringConversionSink startChunkedConversion(Sink<List<int>> sink) =>
       _PercentDecoderSink(sink);
 }
 
@@ -60,7 +62,8 @@ class _PercentDecoderSink extends StringConversionSinkBase {
 
   _PercentDecoderSink(this._sink);
 
-  void addSlice(String string, int start, int end, bool isLast) {
+  @override
+    void addSlice(String string, int start, int end, bool isLast) {
     RangeError.checkValidRange(start, end, string.length);
 
     if (start == end) {
@@ -91,10 +94,12 @@ class _PercentDecoderSink extends StringConversionSinkBase {
     if (isLast) _close(string, end);
   }
 
-  ByteConversionSink asUtf8Sink(bool allowMalformed) =>
+  @override
+    ByteConversionSink asUtf8Sink(bool allowMalformed) =>
       _PercentDecoderByteSink(_sink);
 
-  void close() => _close();
+  @override
+    void close() => _close();
 
   /// Like [close], but includes [string] and [index] in the [FormatException]
   /// if one is thrown.
@@ -124,9 +129,11 @@ class _PercentDecoderByteSink extends ByteConversionSinkBase {
 
   _PercentDecoderByteSink(this._sink);
 
-  void add(List<int> chunk) => addSlice(chunk, 0, chunk.length, false);
+  @override
+    void add(List<int> chunk) => addSlice(chunk, 0, chunk.length, false);
 
-  void addSlice(List<int> chunk, int start, int end, bool isLast) {
+  @override
+    void addSlice(List<int> chunk, int start, int end, bool isLast) {
     RangeError.checkValidRange(start, end, chunk.length);
 
     if (start == end) {
@@ -156,6 +163,7 @@ class _PercentDecoderByteSink extends ByteConversionSinkBase {
     if (isLast) _close(chunk, end);
   }
 
+  @override
   void close() => _close();
 
   /// Like [close], but includes [chunk] and [index] in the [FormatException]

--- a/lib/src/percent/decoder.dart
+++ b/lib/src/percent/decoder.dart
@@ -29,7 +29,7 @@ class PercentDecoder extends Converter<String, List<int>> {
   const PercentDecoder._();
 
   @override
-    List<int> convert(String input) {
+  List<int> convert(String input) {
     var buffer = Uint8Buffer();
     var lastDigit = _decode(input.codeUnits, 0, input.length, buffer);
 
@@ -42,7 +42,7 @@ class PercentDecoder extends Converter<String, List<int>> {
   }
 
   @override
-    StringConversionSink startChunkedConversion(Sink<List<int>> sink) =>
+  StringConversionSink startChunkedConversion(Sink<List<int>> sink) =>
       _PercentDecoderSink(sink);
 }
 
@@ -63,7 +63,7 @@ class _PercentDecoderSink extends StringConversionSinkBase {
   _PercentDecoderSink(this._sink);
 
   @override
-    void addSlice(String string, int start, int end, bool isLast) {
+  void addSlice(String string, int start, int end, bool isLast) {
     RangeError.checkValidRange(start, end, string.length);
 
     if (start == end) {
@@ -95,11 +95,11 @@ class _PercentDecoderSink extends StringConversionSinkBase {
   }
 
   @override
-    ByteConversionSink asUtf8Sink(bool allowMalformed) =>
+  ByteConversionSink asUtf8Sink(bool allowMalformed) =>
       _PercentDecoderByteSink(_sink);
 
   @override
-    void close() => _close();
+  void close() => _close();
 
   /// Like [close], but includes [string] and [index] in the [FormatException]
   /// if one is thrown.
@@ -130,10 +130,10 @@ class _PercentDecoderByteSink extends ByteConversionSinkBase {
   _PercentDecoderByteSink(this._sink);
 
   @override
-    void add(List<int> chunk) => addSlice(chunk, 0, chunk.length, false);
+  void add(List<int> chunk) => addSlice(chunk, 0, chunk.length, false);
 
   @override
-    void addSlice(List<int> chunk, int start, int end, bool isLast) {
+  void addSlice(List<int> chunk, int start, int end, bool isLast) {
     RangeError.checkValidRange(start, end, chunk.length);
 
     if (start == end) {

--- a/lib/src/percent/encoder.dart
+++ b/lib/src/percent/encoder.dart
@@ -23,10 +23,10 @@ class PercentEncoder extends Converter<List<int>, String> {
   const PercentEncoder._();
 
   @override
-    String convert(List<int> input) => _convert(input, 0, input.length);
+  String convert(List<int> input) => _convert(input, 0, input.length);
 
   @override
-    ByteConversionSink startChunkedConversion(Sink<String> sink) =>
+  ByteConversionSink startChunkedConversion(Sink<String> sink) =>
       _PercentEncoderSink(sink);
 }
 
@@ -38,12 +38,12 @@ class _PercentEncoderSink extends ByteConversionSinkBase {
   _PercentEncoderSink(this._sink);
 
   @override
-    void add(List<int> chunk) {
+  void add(List<int> chunk) {
     _sink.add(_convert(chunk, 0, chunk.length));
   }
 
   @override
-    void addSlice(List<int> chunk, int start, int end, bool isLast) {
+  void addSlice(List<int> chunk, int start, int end, bool isLast) {
     RangeError.checkValidRange(start, end, chunk.length);
     _sink.add(_convert(chunk, start, end));
     if (isLast) _sink.close();

--- a/lib/src/percent/encoder.dart
+++ b/lib/src/percent/encoder.dart
@@ -22,9 +22,11 @@ const percentEncoder = PercentEncoder._();
 class PercentEncoder extends Converter<List<int>, String> {
   const PercentEncoder._();
 
-  String convert(List<int> bytes) => _convert(bytes, 0, bytes.length);
+  @override
+    String convert(List<int> input) => _convert(input, 0, input.length);
 
-  ByteConversionSink startChunkedConversion(Sink<String> sink) =>
+  @override
+    ByteConversionSink startChunkedConversion(Sink<String> sink) =>
       _PercentEncoderSink(sink);
 }
 
@@ -35,16 +37,19 @@ class _PercentEncoderSink extends ByteConversionSinkBase {
 
   _PercentEncoderSink(this._sink);
 
-  void add(List<int> chunk) {
+  @override
+    void add(List<int> chunk) {
     _sink.add(_convert(chunk, 0, chunk.length));
   }
 
-  void addSlice(List<int> chunk, int start, int end, bool isLast) {
+  @override
+    void addSlice(List<int> chunk, int start, int end, bool isLast) {
     RangeError.checkValidRange(start, end, chunk.length);
     _sink.add(_convert(chunk, start, end));
     if (isLast) _sink.close();
   }
 
+  @override
   void close() {
     _sink.close();
   }

--- a/lib/src/string_accumulator_sink.dart
+++ b/lib/src/string_accumulator_sink.dart
@@ -24,7 +24,7 @@ class StringAccumulatorSink extends StringConversionSinkBase {
   }
 
   @override
-    void add(String str) {
+  void add(String str) {
     if (_isClosed) {
       throw StateError("Can't add to a closed sink.");
     }
@@ -33,7 +33,7 @@ class StringAccumulatorSink extends StringConversionSinkBase {
   }
 
   @override
-    void addSlice(String str, int start, int end, bool isLast) {
+  void addSlice(String str, int start, int end, bool isLast) {
     if (_isClosed) {
       throw StateError("Can't add to a closed sink.");
     }

--- a/lib/src/string_accumulator_sink.dart
+++ b/lib/src/string_accumulator_sink.dart
@@ -23,23 +23,26 @@ class StringAccumulatorSink extends StringConversionSinkBase {
     _buffer.clear();
   }
 
-  void add(String chunk) {
+  @override
+    void add(String str) {
     if (_isClosed) {
       throw StateError("Can't add to a closed sink.");
     }
 
-    _buffer.write(chunk);
+    _buffer.write(str);
   }
 
-  void addSlice(String chunk, int start, int end, bool isLast) {
+  @override
+    void addSlice(String str, int start, int end, bool isLast) {
     if (_isClosed) {
       throw StateError("Can't add to a closed sink.");
     }
 
-    _buffer.write(chunk.substring(start, end));
+    _buffer.write(str.substring(start, end));
     if (isLast) _isClosed = true;
   }
 
+  @override
   void close() {
     _isClosed = true;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: convert
-version: 3.0.1
+version: 3.0.2-dev
 description: >-
   Utilities for converting between data representations.
   Provides a number of Sink, Codec, Decoder, and Encoder types.
 repository: https://github.com/dart-lang/convert
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   typed_data: ^1.3.0
 
 dev_dependencies:
-  pedantic: ^1.10.0
-  test: ^1.16.0-nullsafety.9
+  lints: ^1.0.0
+  test: ^1.16.0

--- a/test/accumulator_sink_test.dart
+++ b/test/accumulator_sink_test.dart
@@ -6,7 +6,7 @@ import 'package:convert/convert.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var sink;
+  late AccumulatorSink sink;
   setUp(() {
     sink = AccumulatorSink<int>();
   });

--- a/test/accumulator_sink_test.dart
+++ b/test/accumulator_sink_test.dart
@@ -25,13 +25,19 @@ void main() {
   });
 
   test("clear() clears the events", () {
-    sink..add(1)..add(2)..add(3);
+    sink
+      ..add(1)
+      ..add(2)
+      ..add(3);
     expect(sink.events, equals([1, 2, 3]));
 
     sink.clear();
     expect(sink.events, isEmpty);
 
-    sink..add(4)..add(5)..add(6);
+    sink
+      ..add(4)
+      ..add(5)
+      ..add(6);
     expect(sink.events, equals([4, 5, 6]));
   });
 

--- a/test/hex_test.dart
+++ b/test/hex_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:convert/convert.dart';
 import 'package:test/test.dart';
@@ -80,7 +81,7 @@ void main() {
 
     group("with chunked conversion", () {
       late List<List<int>> results;
-      var sink;
+      late StringConversionSink sink;
       setUp(() {
         results = [];
         var controller = StreamController<List<int>>(sync: true);

--- a/test/percent_test.dart
+++ b/test/percent_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:convert/convert.dart';
 import 'package:test/test.dart';
@@ -90,7 +91,7 @@ void main() {
 
     group("with chunked conversion", () {
       late List<List<int>> results;
-      var sink;
+      late StringConversionSink sink;
       setUp(() {
         results = [];
         var controller = StreamController<List<int>>(sync: true);

--- a/test/string_accumulator_sink_test.dart
+++ b/test/string_accumulator_sink_test.dart
@@ -6,7 +6,7 @@ import 'package:convert/convert.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var sink;
+  late StringAccumulatorSink sink;
   setUp(() {
     sink = StringAccumulatorSink();
   });


### PR DESCRIPTION
Fix existing violations of lints:
- `annotate_overrides`
- `avoid_renaming_method_parameters`
- `prefer_typing_uninitialized_variables`