### PR TITLE
Add missing increment to custom code-page decoder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+* Fix bug in `CodePage` class. See issue [#47](https://github.com/dart-lang/convert/issues/47).
+
 ## 3.0.0
 
 * Stable null safety release.

--- a/lib/src/codepage.dart
+++ b/lib/src/codepage.dart
@@ -256,7 +256,7 @@ CodePageDecoder _createDecoder(String characters) {
       throw ArgumentError.value(
           characters, "characters", "Must contain 256 characters");
     }
-    result[i] = char;
+    result[i++] = char;
     allChars |= char;
   }
   if (i < 256) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: convert
-version: 3.0.0
+version: 3.0.1
 description: >-
   Utilities for converting between data representations.
   Provides a number of Sink, Codec, Decoder, and Encoder types.

--- a/test/codepage_test.dart
+++ b/test/codepage_test.dart
@@ -60,4 +60,15 @@ void main() {
     var decoded = latin3.decode(encoded, allowInvalid: true);
     expect(decoded, latin2text);
   });
+
+  test("Custom code page", () {
+    var cp = CodePage("custom", "ABCDEF" + "\uFFFD" * 250);
+    var result = cp.encode("BADCAFE");
+    expect(result, [1, 0, 3, 2, 0, 5, 4]);
+    expect(() => cp.encode("GAD"), throwsFormatException);
+    expect(cp.encode("GAD", invalidCharacter: 0x3F), [0x3F, 0, 3]);
+    expect(cp.decode([1, 0, 3, 2, 0, 5, 4]), "BADCAFE");
+    expect(() => cp.decode([6, 1, 255]), throwsFormatException);
+    expect(cp.decode([6, 1, 255], allowInvalid: true), "\u{FFFD}B\u{FFFD}");
+  });
 }


### PR DESCRIPTION
Fixes dart-lang/core#271.

This fix was never merged into master. My bad.
