### PR TITLE
Add chunked decoding support to CodePage

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.19.0, dev]
+        sdk: [3.0.0, dev]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.1.2-dev
 
 - Require Dart 2.19
+- Add chunked decoding support (`startChunkedConversion`) for `CodePage`
+  encodings.
 
 ## 3.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.1.2-dev
 
-- Require Dart 2.19
+- Require Dart 3.0
 - Add chunked decoding support (`startChunkedConversion`) for `CodePage`
   encodings.
 

--- a/lib/src/codepage.dart
+++ b/lib/src/codepage.dart
@@ -279,21 +279,15 @@ CodePageDecoder _createDecoder(String characters) {
 
 /// An input [ByteConversionSink] for decoders where each input byte can be be
 /// considered independantly.
-class _CodePageDecoderSink implements ByteConversionSink {
+class _CodePageDecoderSink extends ByteConversionSink {
   final Sink<String> _output;
-  final String Function(List<int> input) _convert;
+  final Converter<List<int>, String> _decoder;
 
-  _CodePageDecoderSink(this._output, this._convert);
+  _CodePageDecoderSink(this._output, this._decoder);
 
   @override
   void add(List<int> chunk) {
-    _output.add(_convert(chunk));
-  }
-
-  @override
-  void addSlice(List<int> chunk, int start, int end, bool isLast) {
-    add(chunk.sublist(start, end));
-    if (isLast) close();
+    _output.add(_decoder.convert(chunk));
   }
 
   @override
@@ -354,7 +348,7 @@ class _NonBmpCodePageDecoder extends Converter<List<int>, String>
 
   @override
   Sink<List<int>> startChunkedConversion(Sink<String> sink) =>
-      _CodePageDecoderSink(sink, convert);
+      _CodePageDecoderSink(sink, this);
 }
 
 class _BmpCodePageDecoder extends Converter<List<int>, String>
@@ -391,7 +385,7 @@ class _BmpCodePageDecoder extends Converter<List<int>, String>
 
   @override
   Sink<List<int>> startChunkedConversion(Sink<String> sink) =>
-      _CodePageDecoderSink(sink, convert);
+      _CodePageDecoderSink(sink, this);
 
   String _convertAllowInvalid(List<int> bytes) {
     var count = bytes.length;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 repository: https://github.com/dart-lang/convert
 
 environment:
-  sdk: '>=2.19.0 <3.0.0'
+  sdk: '^3.0.0'
 
 dependencies:
   typed_data: ^1.3.0

--- a/test/codepage_test.dart
+++ b/test/codepage_test.dart
@@ -114,11 +114,11 @@ void main() {
       expect(cp.decode([1, 0, 3, 2, 0, 5, 4]), 'BADCAFE');
     });
 
-    test('undecode byte', () {
+    test('undecodable byte', () {
       expect(() => cp.decode([6, 1, 255]), throwsFormatException);
     });
 
-    test('undecode byte with allowInvalid', () {
+    test('undecodable byte with allowInvalid', () {
       expect(cp.decode([6, 1, 255], allowInvalid: true), '\u{FFFD}B\u{FFFD}');
     });
 

--- a/test/codepage_test.dart
+++ b/test/codepage_test.dart
@@ -93,9 +93,7 @@ void main() {
   });
 
   group('Custom code page', () {
-    late final CodePage cp;
-
-    setUpAll(() => cp = CodePage('custom', "ABCDEF${"\uFFFD" * 250}"));
+    late final cp = CodePage('custom', "ABCDEF${"\uFFFD" * 250}");
 
     test('simple encode', () {
       var result = cp.encode('BADCAFE');

--- a/test/codepage_test.dart
+++ b/test/codepage_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+import 'dart:core';
 import 'dart:typed_data';
 
 import 'package:convert/convert.dart';
@@ -25,24 +27,52 @@ void main() {
     latinThai,
     latinArabic
   ]) {
-    test('${cp.name} codepage', () {
-      // All ASCII compatible.
-      for (var byte = 0x20; byte < 0x7f; byte++) {
-        expect(cp[byte], byte);
-      }
-      // Maps both directions.
-      for (var byte = 0; byte < 256; byte++) {
-        var char = cp[byte];
-        if (char != 0xFFFD) {
-          var string = String.fromCharCode(char);
-          expect(cp.encode(string), [byte]);
-          expect(cp.decode([byte]), string);
+    group('${cp.name} codepage', () {
+      test('ascii compatible', () {
+        for (var byte = 0x20; byte < 0x7f; byte++) {
+          expect(cp[byte], byte);
         }
-      }
-      expect(() => cp.decode([0xfffd]), throwsA(isA<FormatException>()));
-      // Decode works like operator[].
-      expect(cp.decode(bytes, allowInvalid: true),
-          String.fromCharCodes([for (var i = 0; i < 256; i++) cp[i]]));
+      });
+
+      test('bidirectional mapping', () {
+        // Maps both directions.
+        for (var byte = 0; byte < 256; byte++) {
+          var char = cp[byte];
+          if (char != 0xFFFD) {
+            var string = String.fromCharCode(char);
+            expect(cp.encode(string), [byte]);
+            expect(cp.decode([byte]), string);
+          }
+        }
+      });
+
+      test('decode invalid characters not allowed', () {
+        expect(() => cp.decode([0xfffd]), throwsA(isA<FormatException>()));
+      });
+
+      test('decode invalid characters allowed', () {
+        // Decode works like operator[].
+        expect(cp.decode(bytes, allowInvalid: true),
+            String.fromCharCodes([for (var i = 0; i < 256; i++) cp[i]]));
+      });
+
+      test('chunked conversion', () {
+        late final String decodedString;
+        final outputSink = StringConversionSink.withCallback(
+            (accumulated) => decodedString = accumulated);
+        final inputSink = cp.decoder.startChunkedConversion(outputSink);
+        final expected = StringBuffer();
+
+        for (var byte = 0; byte < 256; byte++) {
+          var char = cp[byte];
+          if (char != 0xFFFD) {
+            inputSink.add([byte]);
+            expected.writeCharCode(char);
+          }
+        }
+        inputSink.close();
+        expect(decodedString, expected.toString());
+      });
     });
   }
   test('latin-2 roundtrip', () {
@@ -62,14 +92,48 @@ void main() {
     expect(decoded, latin2text);
   });
 
-  test('Custom code page', () {
-    var cp = CodePage('custom', "ABCDEF${"\uFFFD" * 250}");
-    var result = cp.encode('BADCAFE');
-    expect(result, [1, 0, 3, 2, 0, 5, 4]);
-    expect(() => cp.encode('GAD'), throwsFormatException);
-    expect(cp.encode('GAD', invalidCharacter: 0x3F), [0x3F, 0, 3]);
-    expect(cp.decode([1, 0, 3, 2, 0, 5, 4]), 'BADCAFE');
-    expect(() => cp.decode([6, 1, 255]), throwsFormatException);
-    expect(cp.decode([6, 1, 255], allowInvalid: true), '\u{FFFD}B\u{FFFD}');
+  group('Custom code page', () {
+    late final CodePage cp;
+
+    setUpAll(() => cp = CodePage('custom', "ABCDEF${"\uFFFD" * 250}"));
+
+    test('simple encode', () {
+      var result = cp.encode('BADCAFE');
+      expect(result, [1, 0, 3, 2, 0, 5, 4]);
+    });
+
+    test('unencodable character', () {
+      expect(() => cp.encode('GAD'), throwsFormatException);
+    });
+
+    test('unencodable character with invalidCharacter', () {
+      expect(cp.encode('GAD', invalidCharacter: 0x3F), [0x3F, 0, 3]);
+    });
+
+    test('simple decode', () {
+      expect(cp.decode([1, 0, 3, 2, 0, 5, 4]), 'BADCAFE');
+    });
+
+    test('undecode byte', () {
+      expect(() => cp.decode([6, 1, 255]), throwsFormatException);
+    });
+
+    test('undecode byte with allowInvalid', () {
+      expect(cp.decode([6, 1, 255], allowInvalid: true), '\u{FFFD}B\u{FFFD}');
+    });
+
+    test('chunked conversion', () {
+      late final String decodedString;
+      final outputSink = StringConversionSink.withCallback(
+          (accumulated) => decodedString = accumulated);
+      final inputSink = cp.decoder.startChunkedConversion(outputSink);
+      inputSink
+        ..add([1])
+        ..add([0])
+        ..add([3]);
+
+      inputSink.close();
+      expect(decodedString, 'BAD');
+    });
   });
 }

--- a/test/codepage_test.dart
+++ b/test/codepage_test.dart
@@ -127,13 +127,30 @@ void main() {
       final outputSink = StringConversionSink.withCallback(
           (accumulated) => decodedString = accumulated);
       final inputSink = cp.decoder.startChunkedConversion(outputSink);
+
       inputSink
         ..add([1])
         ..add([0])
-        ..add([3]);
-
-      inputSink.close();
+        ..add([3])
+        ..close();
       expect(decodedString, 'BAD');
+    });
+
+    test('chunked conversion - byte conversion sink', () {
+      late final String decodedString;
+      final outputSink = StringConversionSink.withCallback(
+          (accumulated) => decodedString = accumulated);
+      final bytes = [1, 0, 3, 2, 0, 5, 4];
+
+      final inputSink = cp.decoder.startChunkedConversion(outputSink);
+      expect(inputSink, isA<ByteConversionSink>());
+
+      (inputSink as ByteConversionSink)
+        ..addSlice(bytes, 1, 3, false)
+        ..addSlice(bytes, 4, 5, false)
+        ..addSlice(bytes, 6, 6, true);
+
+      expect(decodedString, 'ADA');
     });
   });
 }


### PR DESCRIPTION
- Add chunked decoding support (`startChunkedConversion`) for `CodePage` encodings. This is straightforward because `CodePage` encodings map a single byte to set of code units so state must be preserved between chunks.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
