### PR TITLE
Update the ISO-8859 encodings to match the current standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.2-dev
+## 4.0.0-dev
 
 - Require Dart 3.0
 - Add chunked decoding support (`startChunkedConversion`) for `CodePage`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Require Dart 3.0
 - Add chunked decoding support (`startChunkedConversion`) for `CodePage`
   encodings.
+- Update the ISO-8859 mappings to the latest version published by the Unicode
+  consortium.
 
 ## 3.1.1
 

--- a/lib/src/codepage.dart
+++ b/lib/src/codepage.dart
@@ -6,12 +6,14 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 /// The ISO-8859-2/Latin-2 (Eastern European) code page.
-final CodePage latin2 =
-    CodePage._bmp('latin-2', '$_ascii$_noControls$_top8859_2');
+///
+/// See https://unicode.org/Public/MAPPINGS/ISO8859/8859-2.TXT
+final CodePage latin2 = CodePage._bmp('latin-2', '$_ascii$_top8859_2');
 
 /// The ISO-8859-3/Latin-3 (South European) code page.
-final CodePage latin3 =
-    CodePage._bmp('latin-3', '$_ascii$_noControls$_top8859_3');
+///
+/// See https://unicode.org/Public/MAPPINGS/ISO8859/8859-3.TXT
+final CodePage latin3 = CodePage._bmp('latin-3', '$_ascii$_top8859_3');
 
 /// The ISO-8859-4/Latin-4 (North European) code page.
 final CodePage latin4 =
@@ -62,14 +64,13 @@ final CodePage latin10 =
     CodePage._bmp('latin-10', '$_ascii$_noControls$_top8859_16');
 
 /// Characters in ISO-8859-2 above the ASCII and top control characters.
-const _top8859_2 = '\xa0Ą˘Ł¤ĽŚ§¨ŠŞŤŹ\xadŽŻ°ą˛ł´ľśˇ¸šşťź˝žż'
-    'ŔÁÂĂÄĹĆÇČÉĘËĚÍÎĎĐŃŇÓÔŐÖ×ŘŮÚŰÜÝŢß'
-    'ŕáâăäĺćçčéęëěíîďđńňóôőö÷řůúűüýţ˙';
+const _top8859_2 = '$_top8859ControlsĄ˘Ł¤ĽŚ§¨ŠŞŤŹ\xadŽŻ°ą˛ł´ľśˇ¸šşťź˝žżŔÁÂĂÄĹĆÇ'
+    'ČÉĘËĚÍÎĎĐŃŇÓÔŐÖ×ŘŮÚŰÜÝŢßŕáâăäĺćçčéęëěíîďđńňóôőö÷řůúűüýţ˙';
 
 /// Characters in ISO-8859-3 above the ASCII and top control characters.
-const _top8859_3 = '\xa0Ħ˘£\uFFFD¤Ĥ§¨İŞĞĴ\xad\uFFFDŻ°ħ²³´µĥ·¸ışğĵ½\uFFFDż'
-    'ÀÁÂ\uFFFDÄĊĈÇÈÉÊËÌÍÎÏ\uFFFDÑÒÓÔĠÖ×ĜÙÚÛÜŬŜß'
-    'àáâ\uFFFDäċĉçèéêëìíîï\uFFFDñòóôġö÷ĝùúûüŭŝ˙';
+const _top8859_3 = '$_top8859ControlsĦ˘£¤\ufffdĤ§¨İŞĞĴ\xad\ufffdŻ°ħ²³´µĥ·¸ışğĵ½'
+    '\ufffdżÀÁÂ\ufffdÄĊĈÇÈÉÊËÌÍÎÏ\ufffdÑÒÓÔĠÖ×ĜÙÚÛÜŬŜßàáâ\ufffdäċĉçèéêëìíîï'
+    '\ufffdñòóôġö÷ĝùúûüŭŝ˙';
 
 /// Characters in ISO-8859-4 above the ASCII and top control characters.
 const _top8859_4 = '\xa0ĄĸŖ¤ĨĻ§¨ŠĒĢŦ\xadŽ¯°ą˛ŗ´ĩļˇ¸šēģŧŊžŋ'
@@ -146,17 +147,21 @@ const _top8859_16 = '\xa0ĄąŁ€„Š§š©Ș«Ź\xadźŻ°±ČłŽ”¶·žč
     'ÀÁÂĂÄĆÆÇÈÉÊËÌÍÎÏĐŃÒÓÔŐÖŚŰÙÚÛÜĘȚß'
     'àáâăäćæçèéêëìíîïđńòóôőöśűùúûüęțÿ';
 
+const _top8859Controls = '\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c'
+    '\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e'
+    '\x9f\xa0';
+
 const _noControls = '\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD'
     '\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD'
     '\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD'
     '\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD';
 
 /// ASCII characters without control characters. Shared by many code pages.
-const _ascii = '$_noControls'
-    // ignore: missing_whitespace_between_adjacent_strings
-    r""" !"#$%&'()*+,-./0123456789:;<=>?"""
-    r'@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_'
-    '`abcdefghijklmnopqrstuvwxyz{|}~\uFFFD';
+// ignore: missing_whitespace_between_adjacent_strings
+const _ascii = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e'
+    '\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x20'
+    r"""!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcd"""
+    'efghijklmnopqrstuvwxyz{|}~\x7f';
 
 /// A mapping between bytes and characters.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: convert
-version: 3.1.2-dev
+version: 4.0.0-dev
 description: >-
   Utilities for converting between data representations.
   Provides a number of Sink, Codec, Decoder, and Encoder types.


### PR DESCRIPTION
- Update the ISO-8859-* encodings to match the current standards at https://unicode.org/Public/MAPPINGS

I generated the mappings using this script:
```python
import unicodedata

top_controls = (r'\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c'
    r'\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e'
    r'\x9f\xa0')

def get_char_mapping(encoding, r=None):
    s = ""
    if r is None:
        r = range(256)
    for i in r:
        try:
            ch = bytes([i]).decode(encoding)
        except UnicodeDecodeError:
            s += '\\ufffd'
        else:
            if ord(ch) > 0xffff:
                raise ValueError('not in BMP')
            if unicodedata.category(ch).startswith('C') or unicodedata.category(ch).startswith('Z'):
                if ord(ch) < 256:
                    s += f'\\x{ord(ch):02x}'
                else:
                    s += f'\\u{ord(ch):04x}'
            else:
                s += ch
    return s

char_map = get_char_mapping('iso8859-3', range(128, 256))
print(char_map.replace(top_controls, '$_topIsoControls'))
```

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
